### PR TITLE
Add Mac desktop support

### DIFF
--- a/AppDelegate.swift
+++ b/AppDelegate.swift
@@ -7,6 +7,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.rootViewController = MapViewController()
+#if targetEnvironment(macCatalyst)
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+            windowScene.sizeRestrictions?.minimumSize = CGSize(width: 600, height: 600)
+            windowScene.title = "Wanderlust Desktop"
+        }
+#endif
         window?.makeKeyAndVisible()
         return true
     }

--- a/Controllers/MapViewController.swift
+++ b/Controllers/MapViewController.swift
@@ -41,7 +41,12 @@ class MapViewController: UIViewController {
     }
 
     private func presentCategorySelection(at coordinate: CLLocationCoordinate2D) {
-        let alert = UIAlertController(title: "Pin Category", message: "Choose a category", preferredStyle: .actionSheet)
+#if targetEnvironment(macCatalyst)
+        let style: UIAlertController.Style = .alert
+#else
+        let style: UIAlertController.Style = .actionSheet
+#endif
+        let alert = UIAlertController(title: "Pin Category", message: "Choose a category", preferredStyle: style)
         for category in PinCategory.allCases {
             alert.addAction(UIAlertAction(title: category.rawValue.capitalized, style: .default) { _ in
                 self.createPin(at: coordinate, category: category)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Wanderlust
+
+Wanderlust is an offline mapping application. It now includes basic desktop support using Mac Catalyst. Build the project in Xcode and enable the "Mac" destination to run the app on macOS.


### PR DESCRIPTION
## Summary
- support running on macOS with Mac Catalyst
- adjust pin selection alert style for Catalyst
- document how to run on desktop

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68538b35f06c8320adb516f782098e95