### PR TITLE
Add R2-based image grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,21 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Through Stillness, A World Moves</title>
-    <!-- Use relative paths so the page works when the project is served from the repo root -->
+    <title>Tiny Squares</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <header>
-        <div class="logo">●</div>
-        <h1>Photography</h1>
-        <div class="kanji">京</div>
+        <div class="logo">TinySquares</div>
     </header>
     <main>
-        <section class="intro">
-            <h2>Through Stillness, A World Moves</h2>
-            <a href="portfolio.html" class="button">View Portfolio</a>
-        </section>
         <section id="gallery" class="gallery"></section>
     </main>
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -34,4 +34,7 @@ async function loadGallery() {
     }
 }
 
-window.addEventListener('DOMContentLoaded', loadGallery);
+window.addEventListener('DOMContentLoaded', () => {
+    document.addEventListener('contextmenu', e => e.preventDefault());
+    loadGallery();
+});

--- a/style.css
+++ b/style.css
@@ -9,34 +9,17 @@ body {
 
 header {
     display: flex;
-    justify-content: space-between;
+    justify-content: center;
     align-items: center;
     padding: 1em 2em;
     font-size: 1.5em;
+    font-weight: bold;
 }
 
 .logo {
     color: #b33b3b;
 }
 
-.kanji {
-    font-family: 'Zen Old Mincho', serif;
-}
-
-.intro h2 {
-    font-size: 2em;
-    margin-top: 0.5em;
-}
-
-.button {
-    display: inline-block;
-    margin-top: 1em;
-    padding: 0.5em 1em;
-    background-color: #b33b3b;
-    color: white;
-    text-decoration: none;
-    border-radius: 4px;
-}
 
 .gallery {
     display: grid;


### PR DESCRIPTION
## Summary
- simplify HTML layout and use a single gallery grid
- remove unused header items and portfolio link
- adjust styles for centered header and grid
- disable right click in `main.js`
- load images and video from the provided R2 bucket

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685fc2734bf88320ac47c5b6d8332724