### PR TITLE
Enable infinite grid scrolling

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ body {
     font-family: 'Noto Sans JP', sans-serif;
     background-color: #f8f8f5;
     color: #1a1a1a;
-    overflow-y: scroll;
+    overflow: scroll; /* allow scrolling in both directions */
 }
 
 body.dark {
@@ -66,12 +66,12 @@ body.dark #theme-toggle {
 
 .gallery {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fill, 200px);
     grid-auto-rows: 200px;
     gap: 2px;
-    padding: 2em 0;
-    max-width: 900px;
-    margin: 0 auto;
+    padding: 2em;
+    width: max-content; /* let the grid grow horizontally */
+    margin: 0;
 }
 
 .gallery img {


### PR DESCRIPTION
## Summary
- allow both vertical and horizontal scrolling
- let the gallery's width grow as more items load

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68606d8d2c14832096a430e16e19bc36